### PR TITLE
Exclude commented entries in chnlist upstream

### DIFF
--- a/update-chnlist.sh
+++ b/update-chnlist.sh
@@ -3,4 +3,4 @@ set -o errexit
 set -o pipefail
 url='https://raw.github.com/felixonmars/dnsmasq-china-list/master/accelerated-domains.china.conf'
 data=$(curl -4sSkL "$url") || { echo "download failed, exit-code: $?"; exit 1; }
-echo "$data" | awk -F/ '{print $2}' | sort | uniq >chnlist.txt
+echo "$data" | awk -F/ '/^[^#]/{print $2}' | sort | uniq >chnlist.txt


### PR DESCRIPTION
Some domains are commented out in `accelerated-domains.china.conf`. They should not be included in `chnlist.txt`.